### PR TITLE
improve logging

### DIFF
--- a/lib/work.js
+++ b/lib/work.js
@@ -7,15 +7,33 @@
  * @param  {Object} dataObject data seed
  */
 function logDebug(model, dataObject) {
-    //TODO givance add code comments here
+    // Print the data seed in a single line of text
     var str = JSON.stringify(dataObject);
     if (str) {
-        str = str.substring(0, 50);
+        var ellipsis = '...';
+        var debugLength = 50 - ellipsis.length;
+        if ( str.length > debugLength ) {
+          str = str.substring(0, debugLength) + ellipsis;
+        }
     }
 
     sails.log.debug(model.adapter.identity + ' ' + str);
 }
 
+/**
+ * @function
+ * @description find or create model 
+ * @param  {Object} model      valid sails model
+ * @param  {Object} dataObject data seed
+ * @param  {Function} next     callback 
+ */
+function findOrCreate(model, dataObject, next) {
+    model.findOrCreate(dataObject, dataObject, function(err, record) {
+        logDebug(model, dataObject);
+        // TODO seed associations
+        next(err, record);
+    });
+}
 
 /**
  * @function
@@ -70,11 +88,8 @@ exports.prepare = function(work, model, seedData) {
     if (_.isPlainObject(seedData)) {
         //push work to be done
         work.push(function(next) {
-            logDebug(model, seedData);
-
             //create seed function
-            model
-                .findOrCreate(seedData, seedData, next);
+            findOrCreate(model, seedData, next);
         });
     }
 
@@ -83,19 +98,14 @@ exports.prepare = function(work, model, seedData) {
         _.forEach(seedData, function(data) {
             //push work to be done
             work.push(function(next) {
-                logDebug(model, data);
-
                 //create seed function
-                model
-                    .findOrCreate(data, data, next);
+                findOrCreate(model, data, next);
             });
         });
     }
 
     //is functional data
     if (_.isFunction(seedData)) {
-        logDebug(model, seedData);
-
         //evaluate function to obtain data
         seedData(function(error, data) {
             //current log error and continue

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "name": "pschuegr",
         "github": "https://github.com/pschuegr"
     }, {
-        "name": "givance",
+        "name": "givanse",
         "github": "https://github.com/givanse"
     }],
     "keywords": [


### PR DESCRIPTION
With this change if an error is thrown the offending seed will be printed right above the error, example:

```
debug: group {"id":3,"name":"group three","users":[1,2]}
error: A hook (`seed`) failed to load!
```
